### PR TITLE
Work around bug allowing undo past the editor.string = x call

### DIFF
--- a/ACEViewSwift/ACEBridge.swift
+++ b/ACEViewSwift/ACEBridge.swift
@@ -141,6 +141,7 @@ class ACEEditor: ACEBridgedObject {
             jsCall("clearSelection")
             jsCall("moveCursorTo", arguments: [0,0])
             jsValue.context.evaluateScript("reportChanges = true;")
+            jsValue.context.evaluateScript("editor.getSession().setUndoManager(new ace.UndoManager());")
             jsValue.context.evaluateScript("ACEView.aceTextDidChange();")
         }
     }


### PR DESCRIPTION
Work around bug allowing undo past the editor.string = x call, which results in undoing to a blank or previous state.
